### PR TITLE
解决ios百度地图大头针二次点击不走代理方法didSelectAnnotationView

### DIFF
--- a/ios/RCTBaiduMap/RCTBaiduMapViewManager.m
+++ b/ios/RCTBaiduMap/RCTBaiduMapViewManager.m
@@ -88,6 +88,7 @@ didSelectAnnotationView:(BMKAnnotationView *)view {
                                     }
                             };
     [self sendEvent:mapView params:event];
+    [mapView deselectAnnotation:view.annotation animated:YES];
 }
 
 - (void) mapView:(BMKMapView *)mapView


### PR DESCRIPTION
解决ios百度地图大头针二次点击不走代理方法didSelectAnnotationView